### PR TITLE
Use async-await for true asynchronous ajax calls

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -191,7 +191,7 @@ SW.methods.contentScriptCommunicator = function(request, sender, sendResponse) {
   if (request.action === 'watchPage') {
     SW.methods.startWatchingQuestion(request.url, function() {
       SW.methods.sendWatchStatus(true, request.url);
-    });
+    }).then();
   }
 
   if (request.action === 'unwatchPage') {
@@ -201,7 +201,7 @@ SW.methods.contentScriptCommunicator = function(request, sender, sendResponse) {
   if (request.action === 'followUser') {
     SW.methods.followUser(request.url, function() {
       SW.methods.sendFollowStatus(true, request.url);
-    });
+    }).then();
   }
 
   if (request.action === 'unfollowUser') {
@@ -220,7 +220,7 @@ SW.methods.init = function() {
   // Add Listener for events from content scripts
   chrome.runtime.onMessage.addListener(SW.methods.contentScriptCommunicator);
 
-  setInterval(SW.methods.fetchNewNotifications, SW.vars.FETCH_NOTIFICATION_INTERVAL);
+  setInterval(SW.methods.fetchNewNotificationsAsync, SW.vars.FETCH_NOTIFICATION_INTERVAL);
   setInterval(SW.methods.fetchUserNotifications, SW.vars.USER_NOTIFICATION_FETCH_INTERVAL);
 };
 


### PR DESCRIPTION
The jQuery `ajax` calls used by StackEye trigger error messages in modern versions of Chrome:

> Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.


(You might have to have the extension in developer mode to see the warnings.)

This happens because StackEye calls the `ajax` function with `async: false`. So much for "Asynchronous JavaScript And XML"!

This pull request changes the synchronous `ajax` calls to be asynchronous, and introduces `async/await` to avoid forcing the entire codebase to use callbacks or Promises (explicitly, at least). `async` methods always return Promises, but in most cases I changed the callers to use `async/await` too, which means they don't have to deal with Promises directly. 

In most cases, I have renamed the affected methods from xxx to xxxAsync, to make it clear that they now return Promises. However, some of the methods were already using callbacks and didn't return anything, so I left their names alone. (For now, they still use callbacks. Technically they do return Promises, so I call `.then()` to avoid warnings.)